### PR TITLE
add serial-coder.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,9 @@
         <li data-lang="en" id="srakrn.me">
           <a href="https://srakrn.me">srakrn.me</a>
         </li>
+        <li data-lang="en" id="serial-coder.com">
+          <a href="https://www.serial-coder.com">serial-coder.com</a>
+        </li>
       </ol>
     </main>
 


### PR DESCRIPTION
Add webring link to https://www.serial-coder.com/.
The webring logo is on the bottom of the front page.