### PR TITLE
Fix: screenshot render emoji

### DIFF
--- a/automation/site-fetcher/Dockerfile
+++ b/automation/site-fetcher/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf fonts-noto libxss1 \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf fonts-noto fonts-noto-color-emoji libxss1 \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This patch fixes a screenshot that cannot render emoji #46
  - Add package [fonts-noto-color-emoji](https://packages.debian.org/buster/fonts-noto-color-emoji) support emoji font from Google

Test Screenshot
![image](https://user-images.githubusercontent.com/24493279/106138839-37df2f80-619f-11eb-8cc5-61932b27f670.png)
