### PR TITLE
E2E: Add more test cases for Webring

### DIFF
--- a/automation/e2e/cypress/integration/webring_e2e.spec.js
+++ b/automation/e2e/cypress/integration/webring_e2e.spec.js
@@ -2,10 +2,9 @@
 
 function commonTests() {
   context("e2e with real user behaviour on random link", () => {
-    let baseURL = "https://webring.wonderful.software/"
 
     it("should navigate to the next link for n-link or last-link", () => {
-      cy.visit(baseURL)
+      cy.visit("/")
       cy.get("li[data-current='1']").then((getCurrentLink) => {
         let isLastChild = Cypress.$(getCurrentLink).is(":last-child")
         cy.get("#next-button").click()
@@ -32,7 +31,7 @@ function commonTests() {
     })
 
     it("should navigate to the previous link for n-link or first-link", () => {
-      cy.visit(baseURL)
+      cy.visit("/")
       cy.get("li[data-current='1']").then((getCurrentLink) => {
         let isFirstChild = Cypress.$(getCurrentLink).is(":first-child")
         cy.get("#previous-button").click()
@@ -59,26 +58,15 @@ function commonTests() {
     })
 
     it("should display the sticky consent banner", () => {
-      cy.visit(baseURL)
+      cy.visit("/")
       cy.get("#for-first-timer").should("be.visible")
     })
 
     it("should hide the sticky consent banner when it is clicked", () => {
-      cy.visit(baseURL)
+      cy.visit("/")
       cy.get("#for-first-timer").should("be.visible")
       cy.get("#for-first-timer").click()
       cy.get("#for-first-timer").should("not.be.visible")
-    })
-
-    it("should contain link on site info section", () => {
-      cy.visit(baseURL)
-      cy.get(".site-info-item__body a")
-        .invoke("attr", "href")
-        .then((link) => {
-          cy.request(link).then((res) => {
-            expect(res.status).to.be.eq(200)
-          })
-        })
     })
   })
 }
@@ -95,32 +83,4 @@ context("Desktop", () => {
     cy.viewport(1024, 768)
   })
   commonTests()
-})
-
-context("data.json", () => {
-  it("should return 200", () => {
-    cy.request(
-      "https://wonderfulsoftware.github.io/webring-site-data/data.json"
-    ).then((res) => {
-      expect(res.status).to.be.eq(200)
-    })
-  })
-
-  it("should have keys", () => {
-    cy.request(
-      "https://wonderfulsoftware.github.io/webring-site-data/data.json"
-    ).then((res) => {
-      cy.log(res.body["dt.in.th"])
-      expect(res.body["dt.in.th"]).to.have.keys(
-        "blurhash",
-        "backlink",
-        "description",
-        "lastUpdated",
-        "mobileImageUrlV2",
-        "number",
-        "url"
-      )
-      expect(res.body["dt.in.th"]["backlink"]).to.have.keys("href", "rect")
-    })
-  })
 })

--- a/automation/e2e/cypress/integration/webring_e2e.spec.js
+++ b/automation/e2e/cypress/integration/webring_e2e.spec.js
@@ -1,0 +1,126 @@
+/// <reference types="cypress" />
+
+function commonTests() {
+  context("e2e with real user behaviour on random link", () => {
+    let baseURL = "https://webring.wonderful.software/"
+
+    it("should navigate to the next link for n-link or last-link", () => {
+      cy.visit(baseURL)
+      cy.get("li[data-current='1']").then((getCurrentLink) => {
+        let isLastChild = Cypress.$(getCurrentLink).is(":last-child")
+        cy.get("#next-button").click()
+        cy.get("li[data-current='1']")
+          .invoke("text")
+          .then((getNewLink) => {
+            if (isLastChild) {
+              cy.get("li[data-current='1']")
+                .first()
+                .invoke("text")
+                .then((getFirstChildText) => {
+                  expect(getNewLink).to.be.eq(getFirstChildText)
+                })
+            } else {
+              cy.get(getCurrentLink)
+                .next()
+                .invoke("text")
+                .then((getFirstChildText) => {
+                  expect(getNewLink).to.be.eq(getFirstChildText)
+                })
+            }
+          })
+      })
+    })
+
+    it("should navigate to the previous link for n-link or first-link", () => {
+      cy.visit(baseURL)
+      cy.get("li[data-current='1']").then((getCurrentLink) => {
+        let isFirstChild = Cypress.$(getCurrentLink).is(":first-child")
+        cy.get("#previous-button").click()
+        cy.get("li[data-current='1']")
+          .invoke("text")
+          .then((getNewLink) => {
+            if (isFirstChild) {
+              cy.get("li[data-current='1']")
+                .last()
+                .invoke("text")
+                .then((getLastChildText) => {
+                  expect(getNewLink).to.be.eq(getLastChildText)
+                })
+            } else {
+              cy.get(getCurrentLink)
+                .prev()
+                .invoke("text")
+                .then((getLastChildText) => {
+                  expect(getNewLink).to.be.eq(getLastChildText)
+                })
+            }
+          })
+      })
+    })
+
+    it("should display the sticky consent banner", () => {
+      cy.visit(baseURL)
+      cy.get("#for-first-timer").should("be.visible")
+    })
+
+    it("should hide the sticky consent banner when it is clicked", () => {
+      cy.visit(baseURL)
+      cy.get("#for-first-timer").should("be.visible")
+      cy.get("#for-first-timer").click()
+      cy.get("#for-first-timer").should("not.be.visible")
+    })
+
+    it("should contain link on site info section", () => {
+      cy.visit(baseURL)
+      cy.get(".site-info-item__body a")
+        .invoke("attr", "href")
+        .then((link) => {
+          cy.request(link).then((res) => {
+            expect(res.status).to.be.eq(200)
+          })
+        })
+    })
+  })
+}
+
+context("Mobile", () => {
+  beforeEach(() => {
+    cy.viewport("iphone-6")
+  })
+  commonTests()
+})
+
+context("Desktop", () => {
+  beforeEach(() => {
+    cy.viewport(1024, 768)
+  })
+  commonTests()
+})
+
+context("data.json", () => {
+  it("should return 200", () => {
+    cy.request(
+      "https://wonderfulsoftware.github.io/webring-site-data/data.json"
+    ).then((res) => {
+      expect(res.status).to.be.eq(200)
+    })
+  })
+
+  it("should have keys", () => {
+    cy.request(
+      "https://wonderfulsoftware.github.io/webring-site-data/data.json"
+    ).then((res) => {
+      cy.log(res.body["dt.in.th"])
+      expect(res.body["dt.in.th"]).to.have.keys(
+        "blurhash",
+        "backlink",
+        "description",
+        "lastUpdated",
+        "mobileImageUrlV2",
+        "number",
+        "url"
+      )
+      expect(res.body["dt.in.th"]["backlink"]).to.have.keys("href", "rect")
+    })
+  })
+})

--- a/automation/e2e/cypress/integration/webring_integration.spec.js
+++ b/automation/e2e/cypress/integration/webring_integration.spec.js
@@ -1,0 +1,27 @@
+context("data.json", () => {
+    it("should return 200", () => {
+      cy.request(
+        "https://wonderfulsoftware.github.io/webring-site-data/data.json"
+      ).then((res) => {
+        expect(res.status).to.be.eq(200)
+      })
+    })
+  
+    it("should have keys", () => {
+      cy.request(
+        "https://wonderfulsoftware.github.io/webring-site-data/data.json"
+      ).then((res) => {
+        cy.log(res.body["dt.in.th"])
+        expect(res.body["dt.in.th"]).to.have.keys(
+          "blurhash",
+          "backlink",
+          "description",
+          "lastUpdated",
+          "mobileImageUrlV2",
+          "number",
+          "url"
+        )
+        expect(res.body["dt.in.th"]["backlink"]).to.have.keys("href", "rect")
+      })
+    })
+  })


### PR DESCRIPTION
Hi @dtinth ,

I would like to submit E2E and add more test cases for Webring.

- e2e with real user behavior on a random link
- should navigate to the next link for n-link or last-link
- should navigate to the previous link for n-link or first-link
- should display the sticky consent banner
- should hide the sticky consent banner when it is clicked
- should contain a link on-site info section
- should return 200 for data.json
- should have keys for data.json

Feel free to change :smile:

Thanks