### PR TITLE
chore - remove devahoy due to planning to be monetization web

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,9 +307,6 @@
         <li data-lang="en" id="0xchai.io" data-owner="phonbopit" data-feed="https://0xchai.io/feed.xml">
           <a href="https://0xchai.io">0xchai.io</a>
         </li>
-        <li data-lang="th" id="devahoy.com" data-owner="phonbopit" data-feed="https://devahoy.com/feed.xml">
-          <a href="https://devahoy.com">devahoy.com</a>
-        </li>
          <li data-lang="th" id="janescience.com" data-owner="janewit" data-feed="https://janescience.com/feed.xml">
           <a href="https://janescience.com">janescience.com</a>
         </li>


### PR DESCRIPTION

> เป็นเว็บไซต์ส่วนตัว ไม่แสวงหากำไร

My website will break the rule, so I remove it because I plan to change from a personal blog to monetize with a membership and courses.

Thanks.