### PR TITLE
Add zartre.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,6 +409,9 @@
         <li data-lang="en" id="tachakorn.com" data-owner="saintzst">
           <a href="https://tachakorn.com">tachakorn.com</a>
         </li>
+        <li data-lang="en" id="zartre.com" data-owner="zartre" data-feed="https://blog.zartre.com/feed">
+          <a href="https://zartre.com">zartre.com</a>
+        </li>
       </ol>
 
       <div id="feed"></div>


### PR DESCRIPTION
Greetings!

This PR adds zartre.com to the webring.
The Webring icon is placed just below the link section.

![image](https://github.com/user-attachments/assets/f86c403b-d47a-4bea-a028-936e947105f9)
