### PR TITLE
Add link to Bluesky social

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,13 @@
 
 - [Facebook](https://www.facebook.com/webring.in.th)
 - [Mastodon](https://mastodon.in.th/@webring)
+- [Bluesky](https://bsky.app/profile/webring.in.th)
 
 เราใช้[ระบบอัตโนมัติ](https://github.com/wonderfulsoftware/webring-social)ในการโพสต์บทความใหม่ขึ้นโซเชียลเน็ตเวิร์ค
 
 หากคุณใช้โปรแกรม[ฟีดรีดเดอร์](https://th.wikipedia.org/wiki/%E0%B8%9F%E0%B8%B5%E0%B8%94%E0%B8%A3%E0%B8%B5%E0%B8%94%E0%B9%80%E0%B8%94%E0%B8%AD%E0%B8%A3%E0%B9%8C) คุณสามารถแอดเว็บในวงแหวนเว็บเข้าไปโดยใช้ไฟล์ [OPML](https://wonderfulsoftware.github.io/webring-site-data/feed.opml)
+
+หากคุณ[ใช้โดเมนของคุณเองเป็น handle บน Bluesky](https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial) คุณจะถูกติดตามโดย[บัญชี Bluesky ของเรา](https://bsky.app/profile/webring.in.th/follows) และถูกเพิ่มเข้าไปในรายชื่อ[สมาชิกวงแหวนเว็บบน Bluesky](https://bsky.app/profile/webring.in.th/lists/3l7kuilcstu2z) โดยอัตโนมัติ
 
 ## แรงบันดาลใจ
 

--- a/index.html
+++ b/index.html
@@ -452,6 +452,9 @@
           <a href="https://mastodon.in.th/@webring"
             >Mastodon</a
           >
+          <a href="https://bsky.app/profile/webring.in.th"
+            >Bluesky</a
+          >
         </p>
       </footer>
     </main>


### PR DESCRIPTION
Fixes #228

Add Bluesky profile link to social media mentions

* Add a link to the Bluesky profile in the footer of `index.html`.
* Add a link to the Bluesky profile in the "โซเชียลเน็ตเวิร์ค" section of `README.md`.
* Mention that if you use your custom domains as a Bluesky handle, you will automatically be followed by our Bluesky account and added to the list of webring members on Bluesky, in Thai, in `README.md`.
* Use Markdown links instead of writing links separately in `README.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wonderfulsoftware/webring/issues/228?shareId=d1da71e1-02e9-4eb2-9dff-394fa0530dc9).