### PR TITLE
Update upload-artifact action to v4 in E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
         run: cd automation/e2e && npx playwright install --with-deps
       - name: Run Playwright tests
         run: cd automation/e2e && yarn playwright test
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
Fixes #230

Update the version of `actions/upload-artifact` in the E2E workflow file.

* Change the version of `actions/upload-artifact` from `v2` to `v4` in `.github/workflows/e2e.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wonderfulsoftware/webring/issues/230?shareId=636bcd31-87f7-49f8-95c7-5678b69b3f54).