### PR TITLE
webring cleanup on 2025-05-27

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,9 +187,6 @@
         <li data-lang="th" id="supavitk.com" data-owner="b5510546671" data-feed="http://www.supavitk.com/feed.xml">
           <a href="http://supavitk.com">supavitk.com</a>
         </li>
-        <li data-lang="th" id="dmg.st" data-owner="iLek2428" data-feed="https://dmg.st/feed/">
-          <a href="https://dmg.st">dmg.st</a>
-        </li>
         <li data-lang="th" id="debuggingsoft.com" data-owner="pingkunga" data-feed="https://naiwaen.debuggingsoft.com/feed/">
           <a href="https://debuggingsoft.com">debuggingsoft.com</a>
         </li>


### PR DESCRIPTION
## Summary
- Remove websites with missing backlinks as detailed in #260
- Sites removed: dmg.st
- This site was identified as having a 503 Service Temporarily Unavailable error

Closes #260