### PR TITLE
fix: truncate long URLs with ellipsis

### DIFF
--- a/index.css
+++ b/index.css
@@ -94,6 +94,12 @@ main {
   background: #fff;
   border-radius: 3px;
   transition: 0.5s all;
+  display: inline-block;
+  max-width: 80%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
 }
 #ring li[data-current] a {
   box-shadow: 0 0 7px #da356777;

--- a/index.css
+++ b/index.css
@@ -95,7 +95,7 @@ main {
   border-radius: 3px;
   transition: 0.5s all;
   display: inline-block;
-  max-width: 80%;
+  max-width: calc(100% - 35px);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Hi, I came across this small UI bug on your website by chance and wanted to help fix it.
This pull request applies a CSS fix to truncate overly long URLs with an ellipsis (...) so they don’t overflow outside the container.
If this change is not needed, feel free to close this PR.

Before
<img width="398" height="72" alt="Before" src="https://github.com/user-attachments/assets/5dcff886-7fcc-4999-8e24-725ff271b7d2" />

After
<img width="407" height="80" alt="After" src="https://github.com/user-attachments/assets/d2e912e2-6ed9-45b9-a4d1-c29cec5fe4c1" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout and readability by enforcing single-line truncation with ellipsis for main content and ring links.
  * Prevented text wrapping and overflow, ensuring long text is neatly capped within available space.
  * Aligned elements consistently (inline-block, bottom alignment) for a cleaner visual presentation.
  * Enhances usability on smaller viewports without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->