### PR TITLE
Change koon2120.work to koon2120.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,8 +364,8 @@
         <li data-lang="th" id="mon.in.th" data-owner="jarmonxd">
           <a href="https://mon.in.th">mon.in.th</a>
         </li>
-        <li data-lang="th" id="koon2120.work" data-owner="koon2120">
-          <a href="https://koon2120.work">koon2120.work</a>
+        <li data-lang="th" id="koon2120.com" data-owner="koon2120">
+          <a href="https://koon2120.com">koon2120.com</a>
         </li>
         <li data-lang="th" id="pokpong.net" data-owner="mcpeth">
           <a href="https://pokpong.net">pokpong.net</a>


### PR DESCRIPTION
# Desktop
<img width="3840" height="2160" alt="desktop" src="https://github.com/user-attachments/assets/eed3d72b-937e-4835-9ddd-260bcc47bf58" />

# Mobile
<img width="1082" height="2400" alt="mobile" src="https://github.com/user-attachments/assets/e52b123b-8767-4df3-bf1d-d68dc03a6f1e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the koon2120 webring entry to use the new koon2120.com domain. The link text and destination now reflect the .com address. Users clicking the koon2120 item will be directed to https://koon2120.com. No other webring entries were modified. This change updates both the visible label and the target URL, replacing the previous koon2120.work address with the current .com domain, improving accuracy for visitors browsing the webring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->