### PR TITLE
webring cleanup on 2025-09-10

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,9 +94,6 @@
         <li data-lang="en" id="wiput.me" data-owner="wiput1999">
           <a href="https://wiput.me">wiput.me</a>
         </li>
-        <li data-lang="en" id="dont.works" data-owner="narate" data-feed="https://i.dont.works/rss/">
-          <a href="https://dont.works">dont.works</a>
-        </li>
         <li data-lang="en" id="icez.net" data-owner="icez" data-feed="https://www.icez.net/blog/feed">
           <a href="https://icez.net">icez.net</a>
         </li>
@@ -178,29 +175,17 @@
         <li data-lang="en" id="jaruwat.dev" data-owner="l3lackMegas">
           <a href="https://jaruwat.dev">jaruwat.dev</a>
         </li>
-        <li data-lang="en" id="khong.xyz" data-owner="Khongchai">
-          <a href="https://khong.xyz">khong.xyz</a>
-        </li>
-        <li data-lang="th" id="poolsawat.com" data-owner="pool13433" data-feed="https://www.poolsawat.com/feed/">
-          <a href="https://www.poolsawat.com">poolsawat.com</a>
-        </li>
         <li data-lang="th" id="supavitk.com" data-owner="b5510546671" data-feed="http://www.supavitk.com/feed.xml">
           <a href="http://supavitk.com">supavitk.com</a>
         </li>
         <li data-lang="th" id="debuggingsoft.com" data-owner="pingkunga" data-feed="https://naiwaen.debuggingsoft.com/feed/">
           <a href="https://debuggingsoft.com">debuggingsoft.com</a>
         </li>
-        <li data-lang="en" id="siriwatk.dev" data-owner="siriwatknp">
-          <a href="https://siriwatk.dev">siriwatk.dev</a>
-        </li>
         <li data-lang="en" id="anuwataravis.dev" data-owner="anuwatavis">
           <a href="https://anuwataravis.dev">anuwataravis.dev</a>
         </li>
         <li data-lang="th" id="yothinix.com" data-owner="yothinix" data-feed="https://yothinix.com/rss/">
           <a href="https://yothinix.com">yothinix.com</a>
-        </li>
-        <li data-lang="th" id="tech.duckfollow.co" data-owner="duckfollow" data-feed="https://tech.duckfollow.co/rss.xml">
-          <a href="https://tech.duckfollow.co">tech.duckfollow.co</a>
         </li>
         <li data-lang="th" id="nitpum.com" data-owner="nitpum" data-feed="https://nitpum.com/index.xml">
           <a href="https://nitpum.com">nitpum.com</a>
@@ -222,9 +207,6 @@
         </li>
         <li data-lang="th" id="utopiabeam.dev" data-owner="UtopiaBeam">
           <a href="https://utopiabeam.dev">utopiabeam.dev</a>
-        </li>
-        <li data-lang="en" id="tinarskii.com" data-owner="tinarskii" data-feed="https://tinarskii.com/rss.xml">
-          <a href="https://www.tinarskii.com">tinarskii.com</a>
         </li>
         <li data-lang="th" id="blog.0002011.xyz" data-owner="kana2011th" data-feed="https://blog.0002011.xyz/api/feed/rss">
           <a href="https://blog.0002011.xyz">blog.0002011.xyz</a>
@@ -249,9 +231,6 @@
         </li>
          <li data-lang="th" id="janescience.com" data-owner="janewit" data-feed="https://janescience.com/feed.xml">
           <a href="https://janescience.com">janescience.com</a>
-        </li>
-          <li data-lang="th" id="taoisaman.com" data-owner="tao-Isaman" data-feed="https://taoisaman.com/feed.xml">
-          <a href="https://taoisaman.com">taoisaman.com</a>
         </li>
         <li data-lang="en" id="khet.me" data-owner="khetkoong">
           <a href="https://khet.me">khet.me</a>
@@ -351,9 +330,6 @@
         </li>
         <li data-lang="en" id="hewkawar.xyz" data-owner="hewkawar">
           <a href="https://hewkawar.xyz">hewkawar.xyz</a>
-        </li>
-        <li data-lang="th" id="blog.eavesdropper.dev" data-owner="un4ckn0wl3z">
-          <a href="https://blog.eavesdropper.dev">blog.eavesdropper.dev</a>
         </li>
         <li data-lang="th" id="varkaria.works" data-owner="varkaria">
           <a href="https://varkaria.works">varkaria.works</a>


### PR DESCRIPTION
## Summary
- Remove websites with missing backlinks as detailed in #274
- Sites removed: dont.works, khong.xyz, poolsawat.com, siriwatk.dev, tech.duckfollow.co, tinarskii.com, taoisaman.com, blog.eavesdropper.dev
- These sites were identified as having missing backlinks, expired domains, or other issues

Closes #274