### PR TITLE
changed "qwrtsdev.xyz" domain to "qwrts.dev"

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,8 +376,8 @@
         <li data-lang="th" id="mengsokool.space" data-owner="mengsokool">
           <a href="https://www.mengsokool.space">mengsokool.space</a>
         </li>
-        <li data-lang="th" id="qwrtsdev.xyz" data-owner="qwrtsdev">
-          <a href="https://qwrtsdev.xyz">qwrtsdev.xyz</a>
+        <li data-lang="th" id="qwrts.dev" data-owner="qwrtsdev">
+          <a href="https://qwrts.dev">qwrts.dev</a>
         </li>
         <li data-lang="en" id="papazeal.com" data-owner="papazeal">
           <a href="https://papazeal.com">papazeal.com</a>


### PR DESCRIPTION
I've changed my site domain to "qwrts.dev"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated web ring entry to use the new domain for correct link routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->