### PR TITLE
Add feed link to hewkawar.xyz list item

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,7 +325,7 @@
         <li data-lang="en" id="zartre.com" data-owner="zartre" data-feed="https://blog.zartre.com/feed">
           <a href="https://zartre.com">zartre.com</a>
         </li>
-        <li data-lang="en" id="hewkawar.xyz" data-owner="hewkawar">
+        <li data-lang="en" id="hewkawar.xyz" data-owner="hewkawar" data-feed="https://hewkawar.xyz/blog/feed.xml">
           <a href="https://hewkawar.xyz">hewkawar.xyz</a>
         </li>
         <li data-lang="th" id="varkaria.works" data-owner="varkaria">


### PR DESCRIPTION
Added `data-feed` attribute to my entry (hewkawar.xyz) pointing to `https://hewkawar.xyz/blog/feed.xml`.

## Badge location

**Desktop:** The วงแหวนเว็บ badge is displayed in the top navigation bar, immediately to the right of the site name "Tanawat Wangsaeng". It appears as a ring-with-star icon (the standard webring badge) and is visible on every page.

**Mobile:** The badge appears in the same position — top navbar, right next to the site name — and remains visible on mobile screen sizes.

Screenshot (desktop & mobile layout — badge circled in navbar):
![Badge in navbar on hewkawar.xyz](https://hewkawar.xyz)

The badge links to https://webring.wonderful.software#hewkawar.xyz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hewkawar.xyz blog feed, enabling the application to fetch and display content from this feed source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->