### PR TITLE
Add data-alias support for backward-compatible hash resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,7 +376,7 @@
         <li data-lang="th" id="mengsokool.space" data-owner="mengsokool">
           <a href="https://www.mengsokool.space">mengsokool.space</a>
         </li>
-        <li data-lang="th" id="qwrts.dev" data-owner="qwrtsdev">
+        <li data-lang="th" id="qwrts.dev" data-owner="qwrtsdev" data-alias="qwrtsdev.xyz">
           <a href="https://qwrts.dev">qwrts.dev</a>
         </li>
         <li data-lang="en" id="papazeal.com" data-owner="papazeal">

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ const components = {
             (hash.match(/[a-z0-9\.-]+/i) || [])[0] || ""
           ).toLowerCase()
           location.replace("#/" + id)
-          const matchedLink = links.find((l) => l.id === id)
+          const matchedLink = links.find((l) => l.id === id || l.alias === id)
           if (matchedLink) {
             sendBeacon("inbound", matchedLink.id)
             transitionInfo.needsInboundTransition = true
@@ -138,7 +138,7 @@ const components = {
       }
       const updateCurrentLink = () => {
         const hash = location.hash
-        const found = links.find((l) => "#/" + l.id === hash)
+        const found = links.find((l) => "#/" + l.id === hash || (l.alias && "#/" + l.alias === hash))
         if (found) {
           currentLink.value = found
           hidingListOnMobile.value = false
@@ -915,6 +915,7 @@ function processLinksInDOM({ onLinkSelected }) {
   return Array.from(document.querySelectorAll("#ring > li")).map(
     (li, index) => {
       const id = li.id
+      const alias = li.dataset.alias
       const a = li.querySelector("a")
       const url = a.href
       const text = a.innerText
@@ -924,6 +925,7 @@ function processLinksInDOM({ onLinkSelected }) {
       const data = Vue.computed(() => siteData[id])
       const link = Vue.reactive({
         id,
+        alias,
         text,
         url,
         a,


### PR DESCRIPTION
## Summary
- After migrating qwrtsdev.xyz → qwrts.dev (PR #311), old bookmarks/hashes to `#/qwrtsdev.xyz` would break
- Adds `data-alias` attribute support in the webring so old hashes still resolve
- Sets `data-alias="qwrtsdev.xyz"` on the qwrts.dev entry
- Updates hash resolution logic in index.js to check aliases

Closes #311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alias support for webring links, enabling alternative naming and navigation methods for improved accessibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wonderfulsoftware/webring/pull/319)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->