### PR TITLE
Request to add pepo.dev to webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,6 +475,9 @@
         <li data-lang="en" id="sastify.xyz" data-owner="s4msh1ne" data-feed="">
           <a href="https://me.sastify.xyz">me.sastify.xyz</a>
         </li>
+        <li data-lang="en" id="pepo.dev" data-owner="pepodev" data-feed="https://pepo.dev/rss.xml">
+          <a href="https://pepo.dev">pepo.dev</a>
+        </li>
       </ol>
 
       <div id="feed"></div>


### PR DESCRIPTION
This pull request adds a new entry to the list of sites in the `index.html` file. The new entry is for "pepo.dev" and includes its owner and RSS feed URL.

- Content Update:
  * Added a new list item for `pepo.dev` with the owner set to `pepodev` and the RSS feed URL set to `https://pepo.dev/rss.xml` in `index.html`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new webring entry for pepo.dev to the webring list, including its owner identifier, RSS feed URL, and link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->