### PR TITLE
docs: clarify PR mergeability criteria in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,28 @@
 
 ## Pull Request Review Playbook
 
+### Mergeability Criteria (ALL three required before approve + squash-merge)
+
+A PR is only ready to merge once **all** of the following hold:
+
+1. **Automated validation comment is present** — the github-actions bot has posted its
+   "PR validation result" comment on the PR.
+   - If it is missing, add the `review` label to trigger it: `gh pr edit <PR_NUMBER> --add-label "review"`.
+   - If the validation workflow fails on a transient GitHub Actions cache error
+     (`BlobNotFound` / "failed to copy" from `productionresultssa11.blob.core.windows.net`),
+     it is a poisoned buildkit cache, not a PR problem. A plain re-run won't fix it —
+     clear the caches first (`gh cache delete --all`), then re-run the failed workflow
+     (`gh run rerun <RUN_ID> --failed`). Confirm with the operator before deleting caches.
+2. **Agent has checked and verified the site** — the agent confirms the HTML element
+   structure, the backlink, the site requirements (personal/non-profit, own domain, real
+   content, icon visible), cross-checking against the validation comment and its screenshot.
+3. **Human operator has done a manual review** — the agent gives the operator the site URL
+   and the operator checks it manually while the agent runs its own checks. Never approve
+   or merge without the operator's explicit confirmation.
+
+Once all three are satisfied and the operator confirms, approve and squash-merge
+(see "If site meets all requirements" below).
+
 ### Initial PR Review Checklist
 1. **Add review label** when starting review: `gh pr edit <PR_NUMBER> --add-label "review"`
    - IMPORTANT: After adding the label, immediately provide the website URL to the user for manual verification


### PR DESCRIPTION
## Summary
- Adds a **Mergeability Criteria** section to the PR Review Playbook in `CLAUDE.md`, making the three required conditions explicit before approve + squash-merge:
  1. Automated GHA validation comment is present (add `review` label to trigger it; if the validation workflow fails on a transient `BlobNotFound` buildkit cache error, clear caches with `gh cache delete --all` and re-run rather than just retrying)
  2. Agent has checked and verified the site (HTML element, backlink, requirements, icon — cross-checked against the validation comment + screenshot)
  3. Human operator has done a manual review (agent provides the URL; never approve/merge without explicit operator confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)