### PR TITLE
Remove 'koon2120.com' from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,9 +337,6 @@
         <li data-lang="th" id="mon.in.th" data-owner="jarmonxd">
           <a href="https://mon.in.th">mon.in.th</a>
         </li>
-        <li data-lang="th" id="koon2120.com" data-owner="koon2120">
-          <a href="https://koon2120.com">koon2120.com</a>
-        </li>
         <li data-lang="th" id="pokpong.net" data-owner="pokpong007" data-feed="https://pokpong.net/feed.xml">
           <a href="https://pokpong.net">pokpong.net</a>
         </li>


### PR DESCRIPTION
Removed the entry for 'koon2120.com' from the list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Replaced the `koon2120.com` entry in the webring with `mon.in.th`.
  * Updated the displayed link and associated entry details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->